### PR TITLE
Copied the interface from the JSON module

### DIFF
--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -1448,6 +1448,7 @@ proc `==`* (a, b: TomlValueRef): bool =
         a.dateTimeVal.hour == b.dateTimeVal.hour and
         a.dateTimeVal.minute == b.dateTimeVal.minute and
         a.dateTimeVal.second == b.dateTimeVal.second and
+        a.dateTimeVal.subsecond == b.dateTimeVal.subsecond and
         a.dateTimeVal.shift == b.dateTimeVal.shift and
         (a.dateTimeVal.shift == true and
           (a.dateTimeVal.isShiftPositive == b.dateTimeVal.isShiftPositive and


### PR DESCRIPTION
This redoes the entire interface with TOML objects to be more or less the exact same as for the JSON module. TOML objects can also be generated in the same way that JSON is with using `?` and `?*` operators, along with a fairly rudimentary `parseToml` macro that takes actual TOML data.

I figured this would be a big enough change that I should ask for some input on it first. Currently the `parseToml` macro really needs some work, but apart from that I think it's a pretty good change. Here is some examples of what is now possible:

```
import parsetoml

# Create a TOML object the same way you would create a JSON object
var data = ?*{
  "hello": "world",
  "someobject": {
    "someInt": 100,
    "someBool": true
  }
}

# Echo out the someBool sub-field and the hello field.
echo data{"someobject", "someBool"}
echo data["hello"]
# Change the hello field to "A new string"
data["hello"] = ?"A new string"

echo "-------------"
echo data # Echo out the TOML data with TOML formatting
echo "-------------"

# This is still a bit rough, read in TOML on compile-time and create a TOML object of it
var data2 = parseToml:
  hello = "world"
  [table]
  foo = [100, 200]
  [anotherTable]
  baz = true

# Write out the same TOML object
echo data2
```
This would output:
```
true
world
-------------
hello = "A new string"
[someobject]
someInt = 100
someBool = true


-------------
hello = "world"
[table]
foo = [100, 200]

[anotherTable]
baz = true
```