### PR TITLE
Run toml-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: go # to install the TOML spec tests using "go get"
 
 cache:
   directories:
@@ -49,6 +49,7 @@ script:
   - nimble install --depsOnly --accept
   - git clone https://github.com/kaushalmodi/nim_config && cp nim_config/config.nims . # Get global config.nims
   - nim test
+  - nimble run_toml_test
   - nim docs
 
 deploy:

--- a/decoder/config.nims
+++ b/decoder/config.nims
@@ -1,0 +1,1 @@
+switch("path", "$projectDir/../src")

--- a/decoder/decoder.nim
+++ b/decoder/decoder.nim
@@ -1,7 +1,13 @@
-import "../src/parsetoml"
-import json
-import streams
-import os
+# https://github.com/BurntSushi/toml-test#try-it-out
+# 1. Install the toml-test using:
+#      go get github.com/BurntSushi/toml-test
+# 2. Build this parsetoml based decoder:
+#      nim c -d:release decoder.nim
+# 3. Test it
+#      toml-test decoder
+
+import json, streams, os
+import parsetoml
 
 var
   fs: FileStream
@@ -20,4 +26,3 @@ let table = parsetoml.parseStream(fs)
 fs.close
 
 echo table.toJson.pretty
-

--- a/parsetoml.nimble
+++ b/parsetoml.nimble
@@ -5,8 +5,21 @@ author        = "Maurizio Tomasi <ziotom78 .at. gmail.com>"
 description   = "Toml parser library for Nim"
 license       = "MIT"
 srcDir        = "src"
-skipDirs      = @["validator"]
+skipDirs      = @["decoder"]
 
 # Deps
 
 requires "nim >= 0.15.0"
+
+from ospaths import `/`, expandTilde
+
+task run_toml_test, "Validates parsetoml using toml-test":
+  exec("nim c -d:release decoder/decoder.nim")
+  # Needs "go" executable to be present in PATH.
+  # For Travis, set "language:" to "go".
+  let
+    goPath = getEnv("GOPATH")
+    tomlTestRepo = "github.com/BurntSushi/toml-test"
+  doAssert goPath != ""
+  exec("go get -u -v " & tomlTestRepo)
+  exec((goPath / "bin" / "toml-test") & " " & "decoder/decoder")

--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -294,6 +294,10 @@ proc stringDelimiter(kind: StringType): char {.inline, noSideEffect.} =
             of StringType.Literal: '\'')
 
 proc parseUnicode(state: var ParserState): string =
+  let nextChar = state.getNextChar()
+  if nextChar notin strutils.HexDigits:
+    raise(newTomlError(state, "invalid Unicode codepoint, " &
+                       "must be a hexadecimal value"))
   let code = parseInt(state, base16, LeadingChar.AllowZero)
   if code notin 0'i64..0xD7FF and code notin 0xE000'i64..0x10FFFF:
     raise(newTomlError(state, "invalid Unicode codepoint, " &


### PR DESCRIPTION
Ref: https://github.com/BurntSushi/toml-test

@PMunch 

I tried to automate validating using `toml-test`. But at least locally, I am seeing these errors:

```Test: string-bad-codepoint (invalid)
Expected an error, but no error was reported.
-------------------------------------------------------------------------------
Test: string-bad-uni-esc (invalid)
Expected an error, but no error was reported.
-------------------------------------------------------------------------------
Test: array-table-array-string-backslash (valid)
Error: unhandled exception: (1:10) unexpected character "{" [TomlError]
-------------------------------------------------------------------------------
Test: float-exponent (valid)
Values for key 'neg' don't match. Expected a value of '0.03' but got '0.03000000000000001'.
-------------------------------------------------------------------------------
Test: inline-table-array (valid)
Error: unhandled exception: (1:12) unexpected character "{" [TomlError]
-------------------------------------------------------------------------------
Test: inline-table (valid)
Error: unhandled exception: (5:17) unexpected character "{" [TomlError]
-------------------------------------------------------------------------------
Test: underscored-float (valid)
Values for key 'electron_mass' don't match. Expected a value of '9.109109383e-31' but got '9.109109383000018e-31'.
119 passed, 7 failed
```

---

**Update**: OK, it fails on Travis too [[ref][0]]

**Update 2**: Updated toml-test output [[ref][1]].

[0]: https://travis-ci.org/NimParsers/parsetoml/builds/445156431#L2038
[1]: https://travis-ci.org/NimParsers/parsetoml/builds/445667053#L2039