### PR TITLE
allow sole 0 as first element of an array

### DIFF
--- a/parsetoml.nimble
+++ b/parsetoml.nimble
@@ -1,6 +1,6 @@
 # Packages
 
-version       = "0.4.0"
+version       = "0.4.1"
 author        = "Maurizio Tomasi <ziotom78 .at. gmail.com>"
 description   = "Toml parser library for Nim"
 license       = "MIT"

--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -740,6 +740,9 @@ proc parseNumOrDate(state: var ParserState): TomlValueRef =
             case nextChar:
               of '.':
                 return parseFloat(state, 0, false)
+              of strutils.Whitespace:
+                state.pushBackChar(nextChar)
+                return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)
               of strutils.Digits:
                 # This must now be a date/time
                 return parseDateOrTime(state, digits = 2, yearOrHour = ord(nextChar) - ord('0'))
@@ -751,6 +754,9 @@ proc parseNumOrDate(state: var ParserState): TomlValueRef =
           case nextChar:
             of '.':
               return parseFloat(state, 0, forcedSign == Neg)
+            of strutils.Whitespace:
+              state.pushBackChar(nextChar)
+              return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)
             else:
               # else is a sole 0
               return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)

--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -740,27 +740,20 @@ proc parseNumOrDate(state: var ParserState): TomlValueRef =
             case nextChar:
               of '.':
                 return parseFloat(state, 0, false)
-              of ',':
-                # the case of a sole 0 in an array like [0, 1]
-                return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)
-              of strutils.Whitespace:
-                state.pushBackChar(nextChar)
-                return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)
               of strutils.Digits:
                 # This must now be a date/time
                 return parseDateOrTime(state, digits = 2, yearOrHour = ord(nextChar) - ord('0'))
               else:
-                raise newTomlError(state, "leading zero not allowed")
+                # else is a sole 0
+                return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)
         else:
           # This must now be a float, or a sole 0
           case nextChar:
             of '.':
               return parseFloat(state, 0, forcedSign == Neg)
-            of strutils.Whitespace:
-              state.pushBackChar(nextChar)
-              return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)
             else:
-              raise newTomlError(state, "leading zero not allowed")
+              # else is a sole 0
+              return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)
       of strutils.Digits - {'0'}:
         # This might be a date/time, or an int or a float
         var

--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -740,6 +740,9 @@ proc parseNumOrDate(state: var ParserState): TomlValueRef =
             case nextChar:
               of '.':
                 return parseFloat(state, 0, false)
+              of ',':
+                # the case of a sole 0 in an array like [0, 1]
+                return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)
               of strutils.Whitespace:
                 state.pushBackChar(nextChar)
                 return TomlValueRef(kind: TomlValueKind.Int, intVal: 0)

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -13,6 +13,10 @@ some_bool = true
 some_string_array = ["abc", "def"]
 some_int_array = [123, 456]
 zero_int_array = [0, 1]
+p_zero_array = [+0, 1]
+m_zero_array = [-0, 1]
+p_zero_float_array = [+0.0, 1.0]
+m_zero_float_array = [-0.0, 1.0]
 
 [input]
 file_name = "test.txt"
@@ -39,6 +43,10 @@ file_name = "test.txt"
       foo["some_string_array"].getElems().mapIt(it.getStr()) == @["abc", "def"]
       foo["some_int_array"].getElems().mapIt(it.getInt()) == @[123, 456]
       foo["zero_int_array"].getElems().mapIt(it.getInt()) == @[0, 1]
+      foo["p_zero_array"].getElems().mapIt(it.getInt()) == @[0, 1]
+      foo["m_zero_array"].getElems().mapIt(it.getInt()) == @[0, 1]
+      foo["p_zero_float_array"].getElems().mapIt(it.getFloat()) == @[0'f64, 1]
+      foo["m_zero_float_array"].getElems().mapIt(it.getFloat()) == @[0'f64, 1]
 
   test "TOML Table/JSON":
     let

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -12,6 +12,7 @@ some_float = 1.23
 some_bool = true
 some_string_array = ["abc", "def"]
 some_int_array = [123, 456]
+zero_int_array = [0, 1]
 
 [input]
 file_name = "test.txt"
@@ -37,6 +38,7 @@ file_name = "test.txt"
     check:
       foo["some_string_array"].getElems().mapIt(it.getStr()) == @["abc", "def"]
       foo["some_int_array"].getElems().mapIt(it.getInt()) == @[123, 456]
+      foo["zero_int_array"].getElems().mapIt(it.getInt()) == @[0, 1]
 
   test "TOML Table/JSON":
     let


### PR DESCRIPTION
Started using TOML in a project the other day and stumbled upon the problem, that something like
```toml
some_array = [0, 1, 2, 3]
```
raises a `leading zero not allowed` error. 

I hope this doesn't have any unwanted side effects. The [TOML test suite](https://github.com/BurntSushi/toml-test) runs fine at least.