### PR TITLE
Update parsetoml.nimble

### DIFF
--- a/parsetoml.nimble
+++ b/parsetoml.nimble
@@ -11,7 +11,7 @@ skipDirs      = @["decoder"]
 
 requires "nim >= 0.18.0"
 
-from ospaths import `/`, expandTilde
+from os import `/`, expandTilde
 
 task run_toml_test, "Validates parsetoml using toml-test":
   exec("nim c -d:release decoder/decoder.nim")


### PR DESCRIPTION
I am working on removing old deprecated stuff from Nim, like pre- `1.0` or so,
your package is on important packages list and still uses Deprecated `ospaths`.
:)
