### PR TITLE
Close the local stream object before leaving parseFile()/parseString()

### DIFF
--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -1270,19 +1270,32 @@ proc parseString*(tomlStr: string, fileName: string = ""): TomlValueRef =
   ## Parses a string of TOML formatted data into a TOML table. The optional
   ## filename is used for error messages.
   let strStream = newStringStream(tomlStr)
-  result = parseStream(strStream, fileName)
+  try:
+    result = parseStream(strStream, fileName)
+  finally:
+    strStream.close()
 
 proc parseFile*(f: File, fileName: string = ""): TomlValueRef =
   ## Parses a file of TOML formatted data into a TOML table. The optional
   ## filename is used for error messages.
   let fStream = newFileStream(f)
-  result = parseStream(fStream, fileName)
+  try:
+    result = parseStream(fStream, fileName)
+  finally:
+    fStream.close()
 
 proc parseFile*(fileName: string): TomlValueRef =
   ## Parses the file found at fileName with TOML formatted data into a TOML
   ## table.
   let fStream = newFileStream(fileName, fmRead)
-  result = parseStream(fStream, fileName)
+  if not isNil(fStream):
+    try:
+      result = parseStream(fStream, fileName)
+    finally:
+      fStream.close()
+  else:
+    raise newException(IOError, "cannot open: " & fileName)
+
 
 proc `$`*(val: TomlDate): string =
   ## Converts the TOML date object into the ISO format read by the parser


### PR DESCRIPTION
I ran into an issue the other day where the OS would stop allowing my application to parse TOML files after a while. I'm thinking that the procs `parseFile()` and `parseString()` should make sure to close the local stream object before returning.

Also, I added a guard against `newFileStream()` returning `nil`. I don't really know what the policy is in this case. I opted to raise an exception, similar to how `io.open()` works instead of initializing the return value and silently returning. Perhaps a better option would be to create a `File` object via `io.open()` and passing that to the other `parseFile()` proc. That way any exception would be raised naturally by the standard library and not manually on this level. But maybe that's overkill.