### PR TITLE
Use normal object copy instad of deepCopy

### DIFF
--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -1915,8 +1915,11 @@ proc copy*(p: TomlValueRef): TomlValueRef =
     for i in items(p.arrayVal):
       result.arrayVal.add(copy(i))
   of TomlValueKind.DateTime:
-    deepCopy(result, p)
+    new(result)
+    result[] = p[]
   of TomlValueKind.Date:
-    deepCopy(result, p)
+    new(result)
+    result[] = p[]
   of TomlValueKind.Time:
-    deepCopy(result, p)
+    new(result)
+    result[] = p[]


### PR DESCRIPTION
.. since TomlValueRef of kind Date, Time and DateTime don't contain
any ref types inside.

This PR separates out the "Used normal object copy instead of deepCopy since TomlValueRef of kind Date, Time and DateTime don't contain any ref types inside." piece from https://github.com/NimParsers/parsetoml/pull/38.

Ref: https://github.com/NimParsers/parsetoml/pull/38#issuecomment-667869797