### PR TITLE
make TOML empty arrays work, add test

### DIFF
--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -1487,7 +1487,8 @@ proc toTomlString*(value: TomlTableRef, parents = ""): string =
       if value.kind == TomlValueKind.Table:
         subtables.add((key: key, value: value))
       elif value.kind == TomlValueKind.Array and
-        value.arrayVal[0].kind == TomlValueKind.Table:
+           value.arrayVal.len > 0 and
+           value.arrayVal[0].kind == TomlValueKind.Table:
         let tables = value.arrayVal.map(toTomlString)
         for table in tables:
           result = result & "[[" & key & "]]\n" & table & "\n"

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -20,6 +20,10 @@ m_zero_array = [-0, 1]
 p_zero_float_array = [+0.0, 1.0]
 m_zero_float_array = [-0.0, 1.0]
 
+[table_with_empty]
+array_with_empty = [["a", "b"], [], [2, 3]]
+array_empty = []
+
 [input]
 file_name = "test.txt"
 """)
@@ -49,6 +53,20 @@ file_name = "test.txt"
       foo["m_zero_array"].getElems().mapIt(it.getInt()) == @[0, 1]
       foo["p_zero_float_array"].getElems().mapIt(it.getFloat()) == @[0'f64, 1]
       foo["m_zero_float_array"].getElems().mapIt(it.getFloat()) == @[0'f64, 1]
+
+  test "TOML empty arrays / arrays with empty fields":
+    let arrays = foo["table_with_empty"]["array_with_empty"]
+    check arrays[0].getElems().mapIt(it.getStr()) == @["a", "b"]
+    check arrays[1].getElems().len == 0
+    check arrays[2].getElems().mapIt(it.getInt()) == @[2, 3]
+    check arrays.toTomlString() == """[["a", "b"], [], [2, 3]]"""
+
+    let tab = foo["table_with_empty"]
+    check tab["array_empty"].kind == TomlValueKind.Array
+    check tab["array_empty"].len == 0
+    check tab.toTomlString() == """array_with_empty = [["a", "b"], [], [2, 3]]
+array_empty = []
+"""
 
   test "TOML Table/JSON":
     let


### PR DESCRIPTION
This fixes the string serialization of TOML arrays that are empty. The access `[0]` was an out of bounds access for the case where the array is empty.

edit: Now that I've done this I'm wondering if this is even valid TOML?