### PR TITLE
parsetoml: make TomlError a non-Defect again

### DIFF
--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -44,7 +44,6 @@ when (NimMajor, NimMinor, NimPatch) < (1, 4, 0):
   type
     IndexDefect* = IndexError
     OverflowDefect* = OverflowError
-    Defect* = Exception
 
 type
   Sign* = enum None, Pos, Neg
@@ -109,7 +108,7 @@ type
     stream*: streams.Stream
     curTableRef*: TomlTableRef
 
-  TomlError* = object of Defect
+  TomlError* = object of ValueError
     location*: ParserState
 
   NumberBase = enum


### PR DESCRIPTION
We should be able to catch an exception if we parse invalid TOML, and
parsetoml raises a `TomlError` for such a situation. However, commits
668491edaff1 and 7126677392aa changed `TomlError` from an `Exception` to a
`Defect` when compiling with Nim 1.4.0 or newer.

From the Nim Manual ([here](https://github.com/nim-lang/Nim/blob/9f408ea9430b/doc/manual.md#exception-hierarchy) and [here](https://github.com/nim-lang/Nim/blob/9f408ea9430b/doc/manual.md#exception-tracking)) a `Defect` should not be caught:

> The exception tree is defined in the `system <system.html>`_ module.
> Every exception inherits from `system.Exception`. Exceptions that indicate
> programming bugs inherit from `system.Defect` (which is a subtype of `Exception`)
> and are strictly speaking not catchable as they can also be mapped to an operation
> that terminates the whole process. If panics are turned into exceptions, these
> exceptions inherit from `Defect`.
> 
> Exceptions that indicate any other runtime error that can be caught inherit from
> `system.CatchableError` (which is a subtype of `Exception`).

> [...]
> Exceptions inheriting from `system.Defect` are not tracked with
> the `.raises: []` exception tracking mechanism. This is more consistent with the
> built-in operations. The following code is valid:
> 
> ```nim
> proc mydiv(a, b): int {.raises: [].} =
>   a div b # can raise an DivByZeroDefect
> ```

Make `TomlError` catchable again, making it inherit from a `CatchableError`
(in particular, `ValueError`). This is consistent with e.g. [`std/parsejson`](https://github.com/nim-lang/Nim/blob/9f408ea9430b/lib/pure/parsejson.nim#L79)
and [`jsony`](https://github.com/treeform/jsony/blob/d0e69bddf838/src/jsony.nim#L3).

---

Pinging @PMunch, as the reviewer of https://github.com/NimParsers/parsetoml/pull/42.