### PR TITLE
patches for strict effects

### DIFF
--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -1739,7 +1739,7 @@ macro `parseToml`*(x: untyped): untyped =
   result = toTomlNew(x)
   echo result.repr
 
-proc `==`* (a, b: TomlValueRef): bool =
+func `==`* (a, b: TomlValueRef): bool =
   ## Check two nodes for equality
   if a.isNil:
     if b.isNil: return true
@@ -1799,7 +1799,7 @@ import hashes
 
 proc hash*(n: OrderedTable[string, TomlValueRef]): Hash {.noSideEffect.}
 
-proc hash*(n: TomlValueRef): Hash =
+proc hash*(n: TomlValueRef): Hash {.noSideEffect.} =
   ## Compute the hash for a TOML node
   case n.kind
   of TomlValueKind.Array:


### PR DESCRIPTION
workaround https://github.com/nim-lang/Nim/issues/19303
ref https://github.com/nim-lang/Nim/pull/19380
see also https://github.com/nim-lang/RFCs/issues/435

stricteffects is enabled for v2.

I tested locally and it should work

![image](https://user-images.githubusercontent.com/43030857/194564363-3bddd815-ce25-4332-8def-4ad540030ecb.png)
