### PR TITLE
parsetoml: support compiling with strictFuncs again

### DIFF
--- a/src/parsetoml.nim
+++ b/src/parsetoml.nim
@@ -1765,7 +1765,8 @@ func `==`* (a, b: TomlValueRef): bool =
       if a.tableVal.len != b.tableVal.len: return false
       for key, val in a.tableVal:
         if not b.tableVal.hasKey(key): return false
-        if b.tableVal[key] != val: return false
+        {.noSideEffect.}:
+          if b.tableVal[key] != val: return false
       result = true
     of TomlValueKind.DateTime:
       result =


### PR DESCRIPTION
Nim 1.6.0 [added][1] an opt-in for the `strictEffects` behavior, which will [become the default in Nim 2.0][2].

Commit bb903611e915 allowed Nim to compile parsetoml with strictEffects, but we could no longer compile with strictFuncs:

```console
$ nim c --experimental:strictFuncs src/parsetoml.nim
/tmp/parsetoml/src/parsetoml.nim(1742, 6) Error: '==' can have side effects
> /tmp/parsetoml/src/parsetoml.nim(1769, 22) Hint: '==' calls `.sideEffect` '[]'
>> /foo/nim-devel/lib/pure/collections/tables.nim(1851, 6) Hint: '[]' called by '=='
```

Add an override so that strictFuncs doesn't complain about the `func`. Simply changing the `func` to a `proc` doesn't work.

Note that the definition of strictFuncs [was recently changed][3].

Closes: #61

[1]: https://nim-lang.org/blog/2021/10/19/version-160-released.html#strict-effects
[2]: https://github.com/nim-lang/Nim/commit/1e15f975b839
[3]: https://forum.nim-lang.org/t/9716

---

I've checked that this works for every combination of strictEffects and strictFuncs, with both Nim 1.6.12 and `devel`. I don't know if we want to make a change in `times.nim` too, but I think we want this PR either way (so that we can compile parsetoml with strictFuncs without waiting for a new Nim release).